### PR TITLE
nix-way: Fix typo for inheriting system dependencies

### DIFF
--- a/src/Tinc/Nix.hs
+++ b/src/Tinc/Nix.hs
@@ -165,7 +165,7 @@ pkgImport ((Package name _), haskellDependencies, systemDependencies) derivation
       | otherwise = "inherit " ++ intercalate " " haskellDependencies ++ "; "
     inheritSystemDependencies
       | null systemDependencies = ""
-      | otherwise = "inherit (pkgs) " ++ intercalate " " systemDependencies ++ "; "
+      | otherwise = "inherit (nixpkgs) " ++ intercalate " " systemDependencies ++ "; "
 
 readDependencies :: Path NixCache -> [HaskellDependency] -> Package -> IO (Package, [HaskellDependency], [SystemDependency])
 readDependencies cache knownHaskellDependencies package = do

--- a/test/Tinc/NixSpec.hs
+++ b/test/Tinc/NixSpec.hs
@@ -76,7 +76,7 @@ spec = do
             , "    { mkDerivation, bar }:"
             , "    mkDerivation { some derivation; }"
             , "  )"
-            , "  { inherit (pkgs) bar; };"
+            , "  { inherit (nixpkgs) bar; };"
             ]
         pkgImport (Package "foo" "0.1.0", [], ["bar"]) derivation `shouldBe` inlined;
 
@@ -114,7 +114,7 @@ spec = do
             , "            { mkDerivation, base, foo, baz }:"
             , "            mkDerivation { some derivation; }"
             , "          )"
-            , "          { inherit foo; inherit (pkgs) baz; };"
+            , "          { inherit foo; inherit (nixpkgs) baz; };"
             , "      };"
             , ""
             , "      newResolver = oldResolver.override {"


### PR DESCRIPTION
(there should really be tests to catch stuff like this)