### PR TITLE
nix-way: Use "haskellPackages" instead of "ghc7103"

### DIFF
--- a/src/Tinc/Facts.hs
+++ b/src/Tinc/Facts.hs
@@ -22,7 +22,7 @@ data Facts = Facts {
 , factsAddSourceCache :: Path AddSourceCache
 , factsNixCache :: Path NixCache
 , factsUseNix :: Bool
-, factsNixResolver :: String
+, factsNixResolver :: Maybe String
 , factsPlugins :: Plugins
 , factsGhcInfo :: GhcInfo
 } deriving (Eq, Show)
@@ -37,11 +37,8 @@ useNix executablePath = do
 isInNixStore :: FilePath -> Bool
 isInNixStore = ("/nix/" `isPrefixOf`)
 
-defaultNixResolver :: String
-defaultNixResolver = "ghc7103"
-
-getNixResolver :: IO String
-getNixResolver = fromMaybe defaultNixResolver <$> lookupEnv "TINC_NIX_RESOLVER"
+getNixResolver :: IO (Maybe String)
+getNixResolver = lookupEnv "TINC_NIX_RESOLVER"
 
 discoverFacts :: FilePath -> IO Facts
 discoverFacts executablePath = getGhcInfo >>= discoverFacts_impl executablePath

--- a/src/Tinc/Install.hs
+++ b/src/Tinc/Install.hs
@@ -68,7 +68,7 @@ installDependencies dryRun facts@Facts{..} = do
       where
         printInstallPlan :: [Package] -> IO ()
         printInstallPlan packages = do
-          mapM_ (putStrLn . ("Installing " ++) . showPackage) packages
+          mapM_ (putStrLn . ("Using " ++) . showPackage) packages
 
 data InstallPlan = InstallPlan {
   _installPlanReusable :: [CachedPackage]

--- a/src/Tinc/Nix.hs
+++ b/src/Tinc/Nix.hs
@@ -57,7 +57,7 @@ shellFile :: FilePath
 shellFile = "shell.nix"
 
 formatNixResolver :: Facts -> String
-formatNixResolver Facts{..} = "haskell.packages." ++ show factsNixResolver
+formatNixResolver Facts{..} = maybe "haskellPackages" (("haskell.packages." ++) . show) factsNixResolver
 
 cabal :: Facts -> [String] -> (String, [String])
 cabal facts args = ("nix-shell", ["-p", formatNixResolver facts ++ ".ghcWithPackages (p: [ p.cabal-install ])", "--pure", "--run", unwords $ "cabal" : map translate args])

--- a/test/Helper.hs
+++ b/test/Helper.hs
@@ -33,7 +33,7 @@ facts = Facts {
 , factsAddSourceCache = error "factsAddSoruceCache"
 , factsNixCache = error "factsNixCache"
 , factsUseNix = False
-, factsNixResolver = defaultNixResolver
+, factsNixResolver = Nothing
 , factsPlugins = []
 , factsGhcInfo = error "factsGhcInfo"
 }

--- a/test/Tinc/NixSpec.hs
+++ b/test/Tinc/NixSpec.hs
@@ -17,10 +17,10 @@ spec = do
 
   describe "cabal" $ do
     it "executes cabal in an empty ghc environment" $ do
-      cabal facts ["sandbox", "init"] `shouldBe` ("nix-shell", ["-p", "haskell.packages.\"ghc7103\".ghcWithPackages (p: [ p.cabal-install ])", "--pure", "--run", "cabal sandbox init"])
+      cabal facts ["sandbox", "init"] `shouldBe` ("nix-shell", ["-p", "haskellPackages.ghcWithPackages (p: [ p.cabal-install ])", "--pure", "--run", "cabal sandbox init"])
 
     it "escapes arguments" $ do
-      cabal facts ["sandbox init"] `shouldBe` ("nix-shell", ["-p", "haskell.packages.\"ghc7103\".ghcWithPackages (p: [ p.cabal-install ])", "--pure", "--run", "cabal 'sandbox init'"])
+      cabal facts ["sandbox init"] `shouldBe` ("nix-shell", ["-p", "haskellPackages.ghcWithPackages (p: [ p.cabal-install ])", "--pure", "--run", "cabal 'sandbox init'"])
 
   describe "nixShell" $ do
     it "executes command in project environment" $ do
@@ -97,7 +97,7 @@ spec = do
           resolver = unlines [
               "{ nixpkgs }:"
             , "rec {"
-            , "  compiler = nixpkgs.haskell.packages.\"ghc7103\";"
+            , "  compiler = nixpkgs.haskellPackages;"
             , "  resolver ="
             , "    let"
             , "      callPackage = compiler.callPackage;"

--- a/tinc.nix
+++ b/tinc.nix
@@ -1,6 +1,6 @@
 { nixpkgs }:
 rec {
-  compiler = nixpkgs.haskell.packages."ghc7103";
+  compiler = nixpkgs.haskellPackages;
   resolver =
     let
       callPackage = compiler.callPackage;


### PR DESCRIPTION
"haskellPackages" is the current/stable ghc resolver.