### PR TITLE
Add tinc-shell plugin

### DIFF
--- a/plugins/tinc-shell
+++ b/plugins/tinc-shell
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -o nounset
+set -o errexit
+
+tinc --fast
+
+if [ "$TINC_USE_NIX" != "yes" ]; then
+  if [ ! -z "$1" ]; then
+    exec tinc exec "$@"
+  else
+    exec tinc exec $SHELL
+  fi
+else
+  EXPR=$(cat <<'EOF'
+  { nixpkgs ? import <nixpkgs> { } }:
+  with nixpkgs;
+  let
+    oldDefault = import ./default.nix { inherit nixpkgs; };
+    oldShell = import ./shell.nix { inherit nixpkgs; };
+  in {
+    default = lib.overrideDerivation oldDefault (oldAttrs: {
+      phases = [ "installPhase" ];
+      name = "${oldAttrs.name}-default-toolchain";
+      installPhase = ''
+        mkdir -p $out
+
+        echo "$PATH " >> $out/paths
+        echo "$LOCALE_ARCHIVE " >> $out/paths
+        echo "$setupCompilerEnvironmentPhase " >> $out/paths
+        echo "$stdenv " >> $out/paths
+        echo "$nativeBuildInputs " >> $out/paths
+      '';
+    });
+
+    shell = lib.overrideDerivation oldShell (oldAttrs: {
+      phases = [ "installPhase" ];
+      name = "${oldAttrs.name}-shell-toolchain";
+      installPhase = ''
+        mkdir -p $out
+
+        echo "$LOCALE_ARCHIVE " >> $out/paths
+        echo "$stdenv " >> $out/paths
+        echo "$nativeBuildInputs " >> $out/paths
+      '';
+    });
+  }
+EOF
+  )
+
+  nix-build -o result-shell -E "$EXPR"
+
+  if [ ! -z "$1" ]; then
+    exec nix-shell --run "$*"
+  else
+    exec nix-shell
+  fi
+fi


### PR DESCRIPTION
Under Nix, this enters nix-shell by creating result-shell derivations which
will not be garbage collected (until they are deleted).

When not under Nix, this runs tinc exec bash.