### PR TITLE
GHCJS Support.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.10
+  - base >= 4.9.1.0
   - graph-wrapper >= 0.2.5
   - language-dot
   - containers

--- a/src/Tinc/Cabal.hs
+++ b/src/Tinc/Cabal.hs
@@ -4,7 +4,7 @@ module Tinc.Cabal where
 import qualified Tinc.Nix as Nix
 import           Tinc.Facts
 
-cabal :: Facts -> [String] -> (String, [String])
-cabal facts@Facts{..}
-  | factsUseNix = Nix.cabal facts
-  | otherwise = (,) "cabal"
+cabal :: Facts -> [String] -> Maybe String -> (String, [String])
+cabal Facts{..} args compiler
+  | factsUseNix = Nix.cabal args compiler
+  | otherwise   = ("cabal", Nix.cabalCompilerParams compiler ++ args)

--- a/src/Tinc/Facts.hs
+++ b/src/Tinc/Facts.hs
@@ -22,7 +22,6 @@ data Facts = Facts {
 , factsAddSourceCache :: Path AddSourceCache
 , factsNixCache :: Path NixCache
 , factsUseNix :: Bool
-, factsNixResolver :: Maybe String
 , factsPlugins :: Plugins
 , factsGhcInfo :: GhcInfo
 } deriving (Eq, Show)
@@ -37,9 +36,6 @@ useNix executablePath = do
 isInNixStore :: FilePath -> Bool
 isInNixStore = ("/nix/" `isPrefixOf`)
 
-getNixResolver :: IO (Maybe String)
-getNixResolver = lookupEnv "TINC_NIX_RESOLVER"
-
 discoverFacts :: FilePath -> IO Facts
 discoverFacts executablePath = getGhcInfo >>= discoverFacts_impl executablePath
 
@@ -47,7 +43,6 @@ discoverFacts_impl :: FilePath -> GhcInfo -> IO Facts
 discoverFacts_impl executablePath ghcInfo = do
   home <- getHomeDirectory
   useNix_ <- useNix executablePath
-  nixResolver <- getNixResolver
   let pluginsDir :: FilePath
       pluginsDir = home </> ".tinc" </> "plugins"
 
@@ -76,7 +71,6 @@ discoverFacts_impl executablePath ghcInfo = do
   , factsAddSourceCache = addSourceCache
   , factsNixCache = nixCache
   , factsUseNix = useNix_
-  , factsNixResolver = nixResolver
   , factsPlugins = plugins
   , factsGhcInfo = ghcInfo
   }

--- a/src/Tinc/Install.hs
+++ b/src/Tinc/Install.hs
@@ -112,7 +112,9 @@ cabalInstallPlan facts@Facts{..} additionalDeps addSourceDependenciesWithVersion
 cabalDryInstall :: (MonadIO m, Fail m, MonadProcess m, MonadCatch m) => Facts -> [String] -> [Constraint] -> m [SimplePackage]
 cabalDryInstall facts args constraints = go >>= parseInstallPlan
   where
-    install xs = uncurry readProcessM (cabal facts ("install" : "--dry-run" : xs)) ""
+    install xs = do
+      compiler <- liftIO getCompiler
+      uncurry readProcessM (cabal facts ("install" : "--dry-run" : xs) compiler) ""
 
     go = do
       r <- try $ install (args ++ constraints)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,12 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- language-dot-0.1.0
+- Cabal-2.0.1.1
+- hpack-0.21.2
+- Glob-0.9.1
+- aeson-1.2.4.0
+resolver: lts-9.21
+nix:
+  enable: true

--- a/test/Helper.hs
+++ b/test/Helper.hs
@@ -29,7 +29,6 @@ facts = Facts {
 , factsAddSourceCache = error "factsAddSoruceCache"
 , factsNixCache = error "factsNixCache"
 , factsUseNix = False
-, factsNixResolver = Nothing
 , factsPlugins = []
 , factsGhcInfo = error "factsGhcInfo"
 }

--- a/tinc.cabal
+++ b/tinc.cabal
@@ -35,7 +35,7 @@ executable tinc
   build-depends:
       Cabal >=2.0.0.2
     , aeson >=0.11.0
-    , base >=4.10
+    , base >=4.9.1.0
     , bytestring
     , call-stack
     , containers
@@ -92,7 +92,7 @@ test-suite spec
     , HUnit >=1.4
     , QuickCheck
     , aeson >=0.11.0
-    , base >=4.10
+    , base >=4.9.1.0
     , bytestring
     , call-stack
     , containers


### PR DESCRIPTION
This was half and half moving the compiler option into tinc.yaml and other half the little fiddly bits that were needed to make everything behave correctly with ghcjs.